### PR TITLE
Use OpenAL Soft on macOS to work around memory leak

### DIFF
--- a/Ameko/Renderers/OpenAlAudioRenderer.cs
+++ b/Ameko/Renderers/OpenAlAudioRenderer.cs
@@ -34,8 +34,9 @@ public class OpenAlAudioRenderer(MediaController mediaController) : IAudioRender
         if (_context is not null)
             return;
 
-        _al = AL.GetApi();
-        _alc = ALContext.GetApi();
+        // Use OpenAL Soft on macOS to work around buffer memory leak
+        _al = OperatingSystem.IsMacOS() ? AL.GetApi(true) : AL.GetApi();
+        _alc = OperatingSystem.IsMacOS() ? ALContext.GetApi(true) : ALContext.GetApi();
 
         _device = _alc.OpenDevice(null);
         if (_device is null)


### PR DESCRIPTION
Potentially due to a bug in the macOS OpenAL implementation (?), audio playback fails to free memory when paused, causing a memory leak that leads to OOM crashes after repeated playback.
Forcing usage of OpenAL Soft seems to be a valid workaround for this issue.

Something I observed while testing was that the `_source _handle` and `_buffer Handle` values exhibit strange behaviour when on native OpenAL (starting from 2400~, `Handle` incrementing on playback and skipping 2403?), whereas forcing OpenAL Soft shows behaviour in line with Windows (fixed 1, 1).
This behaviour is shown in the videos below, alongside memory usage before and after the change.

https://github.com/user-attachments/assets/6655ce21-f425-4b4b-bae7-dab2b62f541e

https://github.com/user-attachments/assets/cbe0fa73-289e-44f3-b406-d1f11d28ae1a

