### PR TITLE
Remove TestableIO from AssCS

### DIFF
--- a/AssCS/AssCS.csproj
+++ b/AssCS/AssCS.csproj
@@ -22,7 +22,5 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="TestableIO.System.IO.Abstractions" />
-    <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" />
   </ItemGroup>
 </Project>

--- a/AssCS/IO/FileParser.cs
+++ b/AssCS/IO/FileParser.cs
@@ -1,8 +1,5 @@
 ﻿// SPDX-License-Identifier: MPL-2.0
 
-using System.IO.Abstractions;
-using System.Text;
-
 namespace AssCS.IO;
 
 /// <summary>
@@ -16,31 +13,4 @@ public abstract class FileParser
     /// <param name="reader">Data to parse</param>
     /// <returns><see cref="Document"/> represented by the <paramref name="reader"/></returns>
     public abstract Document Parse(TextReader reader);
-
-    /// <summary>
-    /// Parse a file into a <see cref="Document"/>
-    /// </summary>
-    /// <param name="fileSystem">FileSystem to use</param>
-    /// <param name="savePath">Path to the file to open</param>
-    /// <returns><see cref="Document"/> at the <paramref name="savePath"/></returns>
-    public Document Parse(IFileSystem fileSystem, Uri savePath)
-    {
-        var path = savePath.LocalPath;
-
-        if (!fileSystem.Directory.Exists(Path.GetDirectoryName(path)))
-            fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(path) ?? "/");
-
-        if (!fileSystem.File.Exists(path))
-            throw new FileNotFoundException("Document not found", path);
-
-        using var fs = fileSystem.FileStream.New(
-            path,
-            FileMode.Open,
-            FileAccess.Read,
-            FileShare.ReadWrite
-        );
-        using var reader = new StreamReader(fs, encoding: Encoding.UTF8);
-
-        return Parse(reader);
-    }
 }

--- a/AssCS/IO/FileWriter.cs
+++ b/AssCS/IO/FileWriter.cs
@@ -1,8 +1,5 @@
 ﻿// SPDX-License-Identifier: MPL-2.0
 
-using System.IO.Abstractions;
-using System.Text;
-
 namespace AssCS.IO;
 
 /// <summary>
@@ -17,36 +14,6 @@ public abstract class FileWriter
     /// <param name="export"><see langword="true"/> if this write is an export</param>
     /// <returns><see langword="true"/> if writing was successful</returns>
     public abstract bool Write(TextWriter writer, bool export = false);
-
-    /// <summary>
-    /// Write an ass document to file
-    /// </summary>
-    /// <param name="fileSystem">FileSystem to use</param>
-    /// <param name="savePath">Path to write to</param>
-    /// <param name="export"><see langword="true"/> if this write is an export</param>
-    /// <returns><see langword="true"/> if writing was successful</returns>
-    /// <exception cref="IOException">If writing fails</exception>
-    public bool Write(IFileSystem fileSystem, Uri savePath, bool export = false)
-    {
-        var path = savePath.LocalPath;
-
-        if (!fileSystem.Directory.Exists(Path.GetDirectoryName(path)))
-            fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(path) ?? "/");
-
-        using var fs = fileSystem.FileStream.New(
-            path,
-            FileMode.Create,
-            FileAccess.Write,
-            FileShare.None
-        );
-        using var writer = new StreamWriter(fs, encoding: Encoding.UTF8);
-
-        var result = Write(writer, export);
-
-        writer.Flush();
-        fs.SetLength(fs.Position);
-        return result;
-    }
 
     /// <summary>
     /// Write an ass document to string

--- a/Holo/IO/AssCSExtensions.cs
+++ b/Holo/IO/AssCSExtensions.cs
@@ -1,0 +1,78 @@
+﻿// SPDX-License-Identifier: MPL-2.0
+
+using System.IO.Abstractions;
+using System.Text;
+using AssCS;
+using AssCS.IO;
+
+namespace Holo.IO;
+
+/// <summary>
+/// Extensions for AssCS
+/// </summary>
+public static class AssCSExtensions
+{
+    /// <summary>
+    /// Write an ass document to file
+    /// </summary>
+    /// <param name="fileWriter">FileWriter to use</param>
+    /// <param name="fileSystem">FileSystem to use</param>
+    /// <param name="savePath">Path to write to</param>
+    /// <param name="export"><see langword="true"/> if this write is an export</param>
+    /// <returns><see langword="true"/> if writing was successful</returns>
+    /// <exception cref="IOException">If writing fails</exception>
+    public static bool Write(
+        this FileWriter fileWriter,
+        IFileSystem fileSystem,
+        Uri savePath,
+        bool export = false
+    )
+    {
+        var path = savePath.LocalPath;
+
+        if (!fileSystem.Directory.Exists(Path.GetDirectoryName(path)))
+            fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(path) ?? "/");
+
+        using var fs = fileSystem.FileStream.New(
+            path,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.None
+        );
+        using var writer = new StreamWriter(fs, encoding: Encoding.UTF8);
+
+        var result = fileWriter.Write(writer, export);
+
+        writer.Flush();
+        fs.SetLength(fs.Position);
+        return result;
+    }
+
+    /// <summary>
+    /// Parse a file into a <see cref="Document"/>
+    /// </summary>
+    /// <param name="fileParser">FileParser to use</param>
+    /// <param name="fileSystem">FileSystem to use</param>
+    /// <param name="savePath">Path to the file to open</param>
+    /// <returns><see cref="Document"/> at the <paramref name="savePath"/></returns>
+    public static Document Parse(this FileParser fileParser, IFileSystem fileSystem, Uri savePath)
+    {
+        var path = savePath.LocalPath;
+
+        if (!fileSystem.Directory.Exists(Path.GetDirectoryName(path)))
+            fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(path) ?? "/");
+
+        if (!fileSystem.File.Exists(path))
+            throw new FileNotFoundException("Document not found", path);
+
+        using var fs = fileSystem.FileStream.New(
+            path,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.ReadWrite
+        );
+        using var reader = new StreamReader(fs, encoding: Encoding.UTF8);
+
+        return fileParser.Parse(reader);
+    }
+}

--- a/Holo/Project.cs
+++ b/Holo/Project.cs
@@ -10,6 +10,7 @@ using AssCS.IO;
 using AssCS.Utilities;
 using Holo.Configuration;
 using Holo.Configuration.Migration;
+using Holo.IO;
 using Holo.Models;
 using Holo.Providers;
 using Microsoft.Extensions.Logging;

--- a/Tests/AssCS.Tests/AssParserTests.cs
+++ b/Tests/AssCS.Tests/AssParserTests.cs
@@ -11,13 +11,11 @@ public class AssParserTests
     [Test]
     public async Task Parse()
     {
-        var fs = new MockFileSystem();
-        var path = MakeTestableUri(fs, "test.ass");
-        fs.AddFile(path.LocalPath, new MockFileData(File1));
+        var reader = new StringReader(File1);
 
         var ap = new AssParser();
 
-        var doc = ap.Parse(fs, path);
+        var doc = ap.Parse(reader);
 
         await Assert.That(doc).IsNotNull();
         await Assert.That(doc.Version).IsEqualTo(AssVersion.V400P);

--- a/Tests/AssCS.Tests/AssWriterTests.cs
+++ b/Tests/AssCS.Tests/AssWriterTests.cs
@@ -11,18 +11,18 @@ public class AssWriterTests
     [Test]
     public async Task Write()
     {
-        var fs = new MockFileSystem();
-        var path = MakeTestableUri(fs, "test.ass");
+        var writer = new StringWriter();
+
         var consumer = new ConsumerInfo("Test Suite", "1.0", "testsuite.com");
         var aw = new AssWriter(CreateDoc(), consumer);
 
-        var result = aw.Write(fs, path);
+        var result = aw.Write(writer);
 
         await Assert.That(result).IsTrue();
-        await Assert.That(fs.FileExists(path.LocalPath)).IsTrue();
 
         // Validate the written file
-        var recreation = new AssParser().Parse(fs, path);
+        var reader = new StringReader(writer.ToString());
+        var recreation = new AssParser().Parse(reader);
 
         await Assert.That(recreation).IsNotNull();
         await Assert
@@ -41,18 +41,18 @@ public class AssWriterTests
     [Test]
     public async Task Write_Export()
     {
-        var fs = new MockFileSystem();
-        var path = MakeTestableUri(fs, "test.ass");
+        var writer = new StringWriter();
         var consumer = new ConsumerInfo("Test Suite", "1.0", "testsuite.com");
         var aw = new AssWriter(CreateDoc(), consumer);
 
-        var result = aw.Write(fs, path, true);
+        var result = aw.Write(writer, true);
 
         await Assert.That(result).IsTrue();
-        await Assert.That(fs.FileExists(path.LocalPath)).IsTrue();
 
         // Validate the written file
-        var recreation = new AssParser().Parse(fs, path);
+        var reader = new StringReader(writer.ToString());
+
+        var recreation = new AssParser().Parse(reader);
 
         await Assert.That(recreation).IsNotNull();
         await Assert

--- a/Tests/AssCS.Tests/SrtParserTests.cs
+++ b/Tests/AssCS.Tests/SrtParserTests.cs
@@ -11,13 +11,11 @@ public class SrtParserTests
     [Test]
     public async Task Parse()
     {
-        var fs = new MockFileSystem();
-        var path = MakeTestableUri(fs, "test.srt");
-        fs.AddFile(path.LocalPath, new MockFileData(File1));
+        var reader = new StringReader(File1);
 
         var sp = new SrtParser();
 
-        var doc = sp.Parse(fs, path);
+        var doc = sp.Parse(reader);
 
         await Assert.That(doc).IsNotNull();
         await Assert.That(doc.StyleManager.Styles.Count).IsEqualTo(1);
@@ -37,13 +35,11 @@ public class SrtParserTests
     [Test]
     public async Task ParseWithTags()
     {
-        var fs = new MockFileSystem();
-        var path = MakeTestableUri(fs, "test.srt");
-        fs.AddFile(path.LocalPath, new MockFileData(File2));
+        var reader = new StringReader(File2);
 
         var sp = new SrtParser();
 
-        var doc = sp.Parse(fs, path);
+        var doc = sp.Parse(reader);
 
         await Assert.That(doc).IsNotNull();
         await Assert.That(doc.EventManager.Events.Count).IsEqualTo(1);
@@ -59,14 +55,12 @@ public class SrtParserTests
     [Test]
     public async Task ExpectedSubtitleIndex()
     {
-        var fs = new MockFileSystem();
-        var path = MakeTestableUri(fs, "test.srt");
-        fs.AddFile(path.LocalPath, new MockFileData("Hello"));
+        var reader = new StringReader("Hello");
 
         var sp = new SrtParser();
 
         await Assert
-            .That(() => sp.Parse(fs, path))
+            .That(() => sp.Parse(reader))
             .Throws<FormatException>()
             .WithMessage("Expected subtitle index at line 1");
     }
@@ -74,14 +68,12 @@ public class SrtParserTests
     [Test]
     public async Task ExpectedTimestamps()
     {
-        var fs = new MockFileSystem();
-        var path = MakeTestableUri(fs, "test.srt");
-        fs.AddFile(path.LocalPath, new MockFileData("1\nHello"));
+        var reader = new StringReader("1\nHello");
 
         var sp = new SrtParser();
 
         await Assert
-            .That(() => sp.Parse(fs, path))
+            .That(() => sp.Parse(reader))
             .Throws<FormatException>()
             .WithMessage("Expected timestamps at line 2");
     }
@@ -89,14 +81,12 @@ public class SrtParserTests
     [Test]
     public async Task UnexpectedEndOfFile()
     {
-        var fs = new MockFileSystem();
-        var path = MakeTestableUri(fs, "test.srt");
-        fs.AddFile(path.LocalPath, new MockFileData("1\n00:00:00,620 --> 00:00:05,630"));
+        var reader = new StringReader("1\n00:00:00,620 --> 00:00:05,630");
 
         var sp = new SrtParser();
 
         await Assert
-            .That(() => sp.Parse(fs, path))
+            .That(() => sp.Parse(reader))
             .Throws<FormatException>()
             .WithMessage("Unexpected end of SRT file");
     }

--- a/Tests/AssCS.Tests/TxtWriterTests.cs
+++ b/Tests/AssCS.Tests/TxtWriterTests.cs
@@ -11,18 +11,17 @@ public class TxtWriterTests
     [Test]
     public async Task Write()
     {
-        var fs = new MockFileSystem();
-        var path = MakeTestableUri(fs, "test.txt");
+        var writer = new StringWriter();
+
         var consumer = new ConsumerInfo("Test Suite", "1.0", "testsuite.com");
         var tw = new TxtWriter(CreateDoc(), consumer);
 
-        var result = tw.Write(fs, path);
+        var result = tw.Write(writer);
 
         await Assert.That(result).IsTrue();
 
         // Validate the written file
-        var stream = fs.FileStream.New(path.LocalPath, FileMode.Open);
-        var reader = new StreamReader(stream);
+        var reader = new StringReader(writer.ToString());
 
         var lines = (await reader.ReadToEndAsync()).Split('\n');
         await Assert.That(lines.Length).IsEqualTo(4 + 1); // Empty line at the end, so +1
@@ -33,20 +32,18 @@ public class TxtWriterTests
     [Test]
     public async Task Write_NoComments()
     {
-        var fs = new MockFileSystem();
-        var path = MakeTestableUri(fs, "test.txt");
+        var writer = new StringWriter();
         var consumer = new ConsumerInfo("Test Suite", "1.0", "testsuite.com");
         var tw = new TxtWriter(CreateDoc(), consumer, includeComments: false);
 
-        var result = tw.Write(fs, path);
+        var result = tw.Write(writer);
 
         await Assert.That(result).IsTrue();
 
         // Validate the written file
-        var stream = fs.FileStream.New(path.LocalPath, FileMode.Open);
-        var reader = new StreamReader(stream);
+        var contents = writer.ToString();
 
-        var lines = (await reader.ReadToEndAsync()).Split('\n');
+        var lines = contents.Split('\n');
         await Assert.That(lines.Length).IsEqualTo(3 + 1);
         await Assert.That(lines[1]).StartsWith("Joe: ");
         await Assert.That(lines[2]).StartsWith("Tim: ");
@@ -55,20 +52,18 @@ public class TxtWriterTests
     [Test]
     public async Task Write_NoActors()
     {
-        var fs = new MockFileSystem();
-        var path = MakeTestableUri(fs, "test.txt");
+        var writer = new StringWriter();
         var consumer = new ConsumerInfo("Test Suite", "1.0", "testsuite.com");
         var tw = new TxtWriter(CreateDoc(), consumer, includeActors: false);
 
-        var result = tw.Write(fs, path);
+        var result = tw.Write(writer);
 
         await Assert.That(result).IsTrue();
 
         // Validate the written file
-        var stream = fs.FileStream.New(path.LocalPath, FileMode.Open);
-        var reader = new StreamReader(stream);
+        var contents = writer.ToString();
 
-        var lines = (await reader.ReadToEndAsync()).Split('\n');
+        var lines = contents.Split('\n');
         await Assert.That(lines.Length).IsEqualTo(4 + 1);
         await Assert.That(lines[1]).StartsWith("Mama");
         await Assert.That(lines[2]).StartsWith("# Mama");
@@ -77,20 +72,18 @@ public class TxtWriterTests
     [Test]
     public async Task Write_NoComments_NoActors()
     {
-        var fs = new MockFileSystem();
-        var path = MakeTestableUri(fs, "test.txt");
+        var writer = new StringWriter();
         var consumer = new ConsumerInfo("Test Suite", "1.0", "testsuite.com");
         var tw = new TxtWriter(CreateDoc(), consumer, includeComments: false, includeActors: false);
 
-        var result = tw.Write(fs, path);
+        var result = tw.Write(writer);
 
         await Assert.That(result).IsTrue();
 
         // Validate the written file
-        var stream = fs.FileStream.New(path.LocalPath, FileMode.Open);
-        var reader = new StreamReader(stream);
+        var contents = writer.ToString();
 
-        var lines = (await reader.ReadToEndAsync()).Split('\n');
+        var lines = contents.Split('\n');
         await Assert.That(lines.Length).IsEqualTo(3 + 1);
         await Assert.That(lines[1]).StartsWith("Mama");
         await Assert.That(lines[2]).StartsWith("Bits SO COOL");


### PR DESCRIPTION
Not really necessary to be part of the lib, adds an extra dependency to the project which all library users then have to include in their own project for an entirely optional feature (reading/writing to a file directly as opposed to just working with a TextReader/Writer). 
This PR moves those two methods to an extension method in Holo (Ameko references it, and both Ameko and Holo use AssCS). Updated tests accordingly to use the Reader/Writer methods instead of the IFileSystem methods.